### PR TITLE
fix origin product url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
  ![Open Source Love](https://badges.frapsoft.com/os/v3/open-source.png?v=103)
 
 ### Magento 2 - Dark Mode for Admin Panel
-This is a continuation of this project: https://github.com/magespices/mage2nostalgia
+This is a continuation of this project: https://github.com/magespices/mage2dark
 
 ### Demo:
 https://darkmode.nanobots.info


### PR DESCRIPTION
The origin project url points to https://github.com/magespices/mage2nostalgia but instead it seems to be https://github.com/magespices/mage2dark

So, this PR changes the link accordingly.